### PR TITLE
Update README.md link to safety checker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ torchrun --nproc_per_node 1 example_text_completion.py \
 The fine-tuned models were trained for dialogue applications. To get the expected features and performance for them, a specific formatting defined in [`chat_completion`](https://github.com/facebookresearch/llama/blob/main/llama/generation.py#L212)
 needs to be followed, including the `INST` and `<<SYS>>` tags, `BOS` and `EOS` tokens, and the whitespaces and breaklines in between (we recommend calling `strip()` on inputs to avoid double-spaces).
 
-You can also deploy additional classifiers for filtering out inputs and outputs that are deemed unsafe. See the llama-recipes repo for [an example](https://github.com/facebookresearch/llama-recipes/blob/main/inference/inference.py) of how to add a safety checker to the inputs and outputs of your inference code.
+You can also deploy additional classifiers for filtering out inputs and outputs that are deemed unsafe. See the llama-recipes repo for  [an example](https://github.com/facebookresearch/llama-recipes/blob/main/examples/chat_completion/chat_completion.py#L87) of how to add a safety checker to the inputs and outputs of your inference code.
 
 Examples using llama-2-7b-chat:
 


### PR DESCRIPTION
The link to the example llama-recipes inference.py was dead. I have replaced the link with the llama-recipes chat_completion.py example here - https://github.com/facebookresearch/llama-recipes/blob/main/examples/chat_completion/chat_completion.py#L87